### PR TITLE
feat:新增github自动化流水线release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,64 @@
+name: Build and renovamen
+
+# 触发条件：当推送新 tag 时
+on:
+  push:
+    tags:
+      - 'v*'
+# 定义环境变量
+env:
+    OUTPUT_DIR: renovamen  # 将 "dist" 定义为变量，可随时修改
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1. 检出代码
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # 2. 设置 Node.js 环境
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # 3. 安装依赖
+      - name: Install dependencies
+        run: npm i
+
+      # 4. 编译 TypeScript
+      - name: Build TypeScript
+        run: npm run build
+
+      # 5. 获取 tag 名称
+      - name: Get tag name
+        id: tag
+        run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      # 6. 创建 tar 文件（包含版本号）
+      - name: Create tar archive with version
+        run: tar -czf ${{ env.OUTPUT_DIR }}-${{ steps.tag.outputs.TAG_NAME }}.tar.gz -C dist .
+
+      # 7. 创建 Release
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.tag.outputs.TAG_NAME }}
+          release_name: Release ${{ steps.tag.outputs.TAG_NAME }}
+          draft: false
+          prerelease: false
+
+      # 8. 上传 tar 文件到 Release
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./${{ env.OUTPUT_DIR }}-${{ steps.tag.outputs.TAG_NAME }}.tar.gz
+          asset_name: ${{ env.OUTPUT_DIR }}-${{ steps.tag.outputs.TAG_NAME }}.tar.gz
+          asset_content_type: application/gzip

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,64 +1,45 @@
-name: Build and renovamen
+name: Build and deploy Astro site to Pages
 
-# 触发条件：当推送新 tag 时
 on:
   push:
-    tags:
-      - 'v*'
-# 定义环境变量
-env:
-    OUTPUT_DIR: renovamen  # 将 "dist" 定义为变量，可随时修改
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
+    env:
+      NODE_VERSION: 20
+
     steps:
-      # 1. 检出代码
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v4
 
-      # 2. 设置 Node.js 环境
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
+      - name: Install, build, and upload your site
+        uses: withastro/action@v2
 
-      # 3. 安装依赖
-      - name: Install dependencies
-        run: npm i
 
-      # 4. 编译 TypeScript
-      - name: Build TypeScript
-        run: npm run build
+  deploy:
+    needs: build
 
-      # 5. 获取 tag 名称
-      - name: Get tag name
-        id: tag
-        run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+    runs-on: ubuntu-latest
 
-      # 6. 创建 tar 文件（包含版本号）
-      - name: Create tar archive with version
-        run: tar -czf ${{ env.OUTPUT_DIR }}-${{ steps.tag.outputs.TAG_NAME }}.tar.gz -C dist .
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
-      # 7. 创建 Release
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.tag.outputs.TAG_NAME }}
-          release_name: Release ${{ steps.tag.outputs.TAG_NAME }}
-          draft: false
-          prerelease: false
-
-      # 8. 上传 tar 文件到 Release
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./${{ env.OUTPUT_DIR }}-${{ steps.tag.outputs.TAG_NAME }}.tar.gz
-          asset_name: ${{ env.OUTPUT_DIR }}-${{ steps.tag.outputs.TAG_NAME }}.tar.gz
-          asset_content_type: application/gzip
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,45 +1,64 @@
-name: Build and deploy Astro site to Pages
+name: Build and renovamen
 
+# 触发条件：当推送新 tag 时
 on:
   push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
-
+    tags:
+      - 'v*'
+# 定义环境变量
+env:
+    OUTPUT_DIR: renovamen  # 将 "dist" 定义为变量，可随时修改
 jobs:
   build:
     runs-on: ubuntu-latest
 
-    env:
-      NODE_VERSION: 20
-
     steps:
-      - name: Checkout
+      # 1. 检出代码
+      - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install, build, and upload your site
-        uses: withastro/action@v2
+      # 2. 设置 Node.js 环境
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
 
+      # 3. 安装依赖
+      - name: Install dependencies
+        run: npm i
 
-  deploy:
-    needs: build
+      # 4. 编译 TypeScript
+      - name: Build TypeScript
+        run: npm run build
 
-    runs-on: ubuntu-latest
+      # 5. 获取 tag 名称
+      - name: Get tag name
+        id: tag
+        run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      # 6. 创建 tar 文件（包含版本号）
+      - name: Create tar archive with version
+        run: tar -czf ${{ env.OUTPUT_DIR }}-${{ steps.tag.outputs.TAG_NAME }}.tar.gz -C dist .
 
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      # 7. 创建 Release
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.tag.outputs.TAG_NAME }}
+          release_name: Release ${{ steps.tag.outputs.TAG_NAME }}
+          draft: false
+          prerelease: false
+
+      # 8. 上传 tar 文件到 Release
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./${{ env.OUTPUT_DIR }}-${{ steps.tag.outputs.TAG_NAME }}.tar.gz
+          asset_name: ${{ env.OUTPUT_DIR }}-${{ steps.tag.outputs.TAG_NAME }}.tar.gz
+          asset_content_type: application/gzip


### PR DESCRIPTION
本家你好，你这个前端个人网站项目，审美太对我胃口了，白嫖了你的项目搭建了个人网站。
我新增了GitHub Action流水线脚本，实现根据push的tag标签实现自动打包releases版本发布自动化脚本实现。

下一步可以在服务器实现sh脚本，实现根据assets最新发布的releases版本实现，自动下载，自动解压替代最新目标服务器项目更新。
最终实现效果，前端tag push之后，实现打包发布-服务器代码下载更新最新版本，实现全自动化。